### PR TITLE
Modify trees value generic type to any for allowing receive map/slice etc

### DIFF
--- a/examples/redblacktreeextended/redblacktreeextended.go
+++ b/examples/redblacktreeextended/redblacktreeextended.go
@@ -6,11 +6,12 @@ package redblacktreeextended
 
 import (
 	"fmt"
+
 	rbt "github.com/ugurcsen/gods-generic/trees/redblacktree"
 )
 
 // RedBlackTreeExtended to demonstrate how to extend a RedBlackTree to include new functions
-type RedBlackTreeExtended[K, T comparable] struct {
+type RedBlackTreeExtended[K comparable, T any] struct {
 	*rbt.Tree[K, T]
 }
 

--- a/trees/avltree/avltree.go
+++ b/trees/avltree/avltree.go
@@ -11,6 +11,7 @@ package avltree
 
 import (
 	"fmt"
+
 	"github.com/ugurcsen/gods-generic/trees"
 	"github.com/ugurcsen/gods-generic/utils"
 )
@@ -19,14 +20,14 @@ import (
 var _ trees.Tree[int] = new(Tree[int, int])
 
 // Tree holds elements of the AVL tree.
-type Tree[K, T comparable] struct {
+type Tree[K comparable, T any] struct {
 	Root       *Node[K, T]         // Root node
 	Comparator utils.Comparator[K] // Key comparator
 	size       int                 // Total number of keys in the tree
 }
 
 // Node is a single element within the tree
-type Node[K, T comparable] struct {
+type Node[K comparable, T any] struct {
 	Key      K
 	Value    T
 	Parent   *Node[K, T]    // Parent node
@@ -35,17 +36,17 @@ type Node[K, T comparable] struct {
 }
 
 // NewWith instantiates an AVL tree with the custom comparator.
-func NewWith[K, T comparable](comparator utils.Comparator[K]) *Tree[K, T] {
+func NewWith[K comparable, T any](comparator utils.Comparator[K]) *Tree[K, T] {
 	return &Tree[K, T]{Comparator: comparator}
 }
 
 // NewWithNumberComparator instantiates an AVL tree with the IntComparator, i.e. keys are of type int.
-func NewWithNumberComparator[T comparable]() *Tree[int, T] {
+func NewWithNumberComparator[T any]() *Tree[int, T] {
 	return &Tree[int, T]{Comparator: utils.NumberComparator[int]}
 }
 
 // NewWithStringComparator instantiates an AVL tree with the StringComparator, i.e. keys are of type string.
-func NewWithStringComparator[T comparable]() *Tree[string, T] {
+func NewWithStringComparator[T any]() *Tree[string, T] {
 	return &Tree[string, T]{Comparator: utils.StringComparator}
 }
 
@@ -291,7 +292,7 @@ func (t *Tree[K, T]) remove(key K, qp **Node[K, T]) bool {
 	return false
 }
 
-func removeMin[K, T comparable](qp **Node[K, T], minKey *K, minVal *T) bool {
+func removeMin[K comparable, T any](qp **Node[K, T], minKey *K, minVal *T) bool {
 	q := *qp
 	if q.Children[0] == nil {
 		*minKey = q.Key
@@ -309,7 +310,7 @@ func removeMin[K, T comparable](qp **Node[K, T], minKey *K, minVal *T) bool {
 	return false
 }
 
-func putFix[K, T comparable](c int8, t **Node[K, T]) bool {
+func putFix[K comparable, T any](c int8, t **Node[K, T]) bool {
 	s := *t
 	if s.b == 0 {
 		s.b = c
@@ -330,7 +331,7 @@ func putFix[K, T comparable](c int8, t **Node[K, T]) bool {
 	return false
 }
 
-func removeFix[K, T comparable](c int8, t **Node[K, T]) bool {
+func removeFix[K comparable, T any](c int8, t **Node[K, T]) bool {
 	s := *t
 	if s.b == 0 {
 		s.b = c
@@ -359,14 +360,14 @@ func removeFix[K, T comparable](c int8, t **Node[K, T]) bool {
 	return true
 }
 
-func singlerot[K, T comparable](c int8, s *Node[K, T]) *Node[K, T] {
+func singlerot[K comparable, T any](c int8, s *Node[K, T]) *Node[K, T] {
 	s.b = 0
 	s = rotate(c, s)
 	s.b = 0
 	return s
 }
 
-func doublerot[K, T comparable](c int8, s *Node[K, T]) *Node[K, T] {
+func doublerot[K comparable, T any](c int8, s *Node[K, T]) *Node[K, T] {
 	a := (c + 1) / 2
 	r := s.Children[a]
 	s.Children[a] = rotate(-c, s.Children[a])
@@ -388,7 +389,7 @@ func doublerot[K, T comparable](c int8, s *Node[K, T]) *Node[K, T] {
 	return p
 }
 
-func rotate[K, T comparable](c int8, s *Node[K, T]) *Node[K, T] {
+func rotate[K comparable, T any](c int8, s *Node[K, T]) *Node[K, T] {
 	a := (c + 1) / 2
 	r := s.Children[a]
 	s.Children[a] = r.Children[a^1]
@@ -446,7 +447,7 @@ func (n *Node[K, T]) walk1(a int) *Node[K, T] {
 	return p
 }
 
-func output[K, T comparable](node *Node[K, T], prefix string, isTail bool, str *string) {
+func output[K comparable, T any](node *Node[K, T], prefix string, isTail bool, str *string) {
 	if node.Children[1] != nil {
 		newPrefix := prefix
 		if isTail {

--- a/trees/avltree/avltree_test.go
+++ b/trees/avltree/avltree_test.go
@@ -6,12 +6,13 @@ package avltree
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ugurcsen/gods-generic/utils"
 	"strings"
 	"testing"
+
+	"github.com/ugurcsen/gods-generic/utils"
 )
 
-func TestAVLTreeGet(t *testing.T) {
+func TestAVLTreeGet1(t *testing.T) {
 	tree := NewWithNumberComparator[string]()
 
 	if actualValue := tree.Size(); actualValue != 0 {
@@ -29,6 +30,50 @@ func TestAVLTreeGet(t *testing.T) {
 	tree.Put(4, "d") // 1->a, 2->b, 3->c, 4->d (in order)
 	tree.Put(5, "e") // 1->a, 2->b, 3->c, 4->d, 5->e (in order)
 	tree.Put(6, "f") // 1->a, 2->b, 3->c, 4->d, 5->e, 6->f (in order)
+	//
+	//  AVLTree
+	//  │       ┌── 6
+	//  │   ┌── 5
+	//  └── 4
+	//      │   ┌── 3
+	//      └── 2
+	//          └── 1
+
+	if actualValue := tree.Size(); actualValue != 6 {
+		t.Errorf("Got %v expected %v", actualValue, 6)
+	}
+
+	if actualValue := tree.GetNode(2).Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+
+	if actualValue := tree.GetNode(4).Size(); actualValue != 6 {
+		t.Errorf("Got %v expected %v", actualValue, 6)
+	}
+
+	if actualValue := tree.GetNode(7).Size(); actualValue != 0 {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+}
+
+func TestAVLTreeGet2(t *testing.T) {
+	tree := NewWithNumberComparator[[]string]()
+
+	if actualValue := tree.Size(); actualValue != 0 {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+
+	if actualValue := tree.GetNode(2).Size(); actualValue != 0 {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+
+	tree.Put(1, []string{"x"}) // 1->x
+	tree.Put(2, []string{"b"}) // 1->x, 2->b (in order)
+	tree.Put(1, []string{"a"}) // 1->a, 2->b (in order, replacement)
+	tree.Put(3, []string{"c"}) // 1->a, 2->b, 3->c (in order)
+	tree.Put(4, []string{"d"}) // 1->a, 2->b, 3->c, 4->d (in order)
+	tree.Put(5, []string{"e"}) // 1->a, 2->b, 3->c, 4->d, 5->e (in order)
+	tree.Put(6, []string{"f"}) // 1->a, 2->b, 3->c, 4->d, 5->e, 6->f (in order)
 	//
 	//  AVLTree
 	//  │       ┌── 6
@@ -656,9 +701,8 @@ func TestAVLTreeIteratorPrevTo(t *testing.T) {
 	}
 }
 
-func TestAVLTreeSerialization(t *testing.T) {
-	tree := NewWith[string, string](utils.StringComparator)
-	tree = NewWithStringComparator[string]()
+func TestAVLTreeSerialization1(t *testing.T) {
+	tree := NewWithStringComparator[string]()
 	tree.Put("c", "3")
 	tree.Put("b", "2")
 	tree.Put("a", "1")
@@ -672,6 +716,48 @@ func TestAVLTreeSerialization(t *testing.T) {
 			t.Errorf("Got %v expected %v", actualValue, "[a,b,c]")
 		}
 		if actualValue := tree.Values(); actualValue[0] != "1" || actualValue[1] != "2" || actualValue[2] != "3" {
+			t.Errorf("Got %v expected %v", actualValue, "[1,2,3]")
+		}
+		if err != nil {
+			t.Errorf("Got error %v", err)
+		}
+	}
+
+	assert()
+
+	bytes, err := tree.ToJSON()
+	assert()
+
+	err = tree.FromJSON(bytes)
+	assert()
+
+	bytes, err = json.Marshal([]interface{}{"a", "b", "c", tree})
+	if err != nil {
+		t.Errorf("Got error %v", err)
+	}
+
+	tree2 := NewWithStringComparator[int]()
+	err = json.Unmarshal([]byte(`{"a":1,"b":2}`), &tree2)
+	if err != nil {
+		t.Errorf("Got error %v", err)
+	}
+}
+
+func TestAVLTreeSerialization2(t *testing.T) {
+	tree := NewWithStringComparator[[1]string]()
+	tree.Put("c", [1]string{"3"})
+	tree.Put("b", [1]string{"2"})
+	tree.Put("a", [1]string{"1"})
+
+	var err error
+	assert := func() {
+		if actualValue, expectedValue := tree.Size(), 3; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+		if actualValue := tree.Keys(); actualValue[0] != "a" || actualValue[1] != "b" || actualValue[2] != "c" {
+			t.Errorf("Got %v expected %v", actualValue, "[a,b,c]")
+		}
+		if actualValue := tree.Values(); actualValue[0][0] != "1" || actualValue[1][0] != "2" || actualValue[2][0] != "3" {
 			t.Errorf("Got %v expected %v", actualValue, "[1,2,3]")
 		}
 		if err != nil {

--- a/trees/avltree/iterator.go
+++ b/trees/avltree/iterator.go
@@ -10,7 +10,7 @@ import "github.com/ugurcsen/gods-generic/containers"
 var _ containers.ReverseIteratorWithKey[int, int] = (*Iterator[int, int])(nil)
 
 // Iterator holding the iterator's state
-type Iterator[K, T comparable] struct {
+type Iterator[K comparable, T any] struct {
 	tree     *Tree[K, T]
 	node     *Node[K, T]
 	position position

--- a/trees/binaryheap/iterator.go
+++ b/trees/binaryheap/iterator.go
@@ -50,7 +50,7 @@ func (iterator *Iterator[T]) Value() T {
 	if end > iterator.heap.Size() {
 		end = iterator.heap.Size()
 	}
-	tmpHeap := NewWith[T](iterator.heap.Comparator)
+	tmpHeap := NewWith(iterator.heap.Comparator)
 	for n := start; n < end; n++ {
 		value, _ := iterator.heap.list.Get(n)
 		tmpHeap.Push(value)

--- a/trees/btree/btree.go
+++ b/trees/btree/btree.go
@@ -19,16 +19,17 @@ package btree
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/ugurcsen/gods-generic/trees"
 	"github.com/ugurcsen/gods-generic/utils"
-	"strings"
 )
 
 // Assert Tree implementation
 var _ trees.Tree[int] = (*Tree[int, int])(nil)
 
 // Tree holds elements of the B-tree
-type Tree[K, T comparable] struct {
+type Tree[K comparable, T any] struct {
 	Root       *Node[K, T]         // Root node
 	Comparator utils.Comparator[K] // Key comparator
 	size       int                 // Total number of keys in the tree
@@ -36,20 +37,20 @@ type Tree[K, T comparable] struct {
 }
 
 // Node is a single element within the tree
-type Node[K, T comparable] struct {
+type Node[K comparable, T any] struct {
 	Parent   *Node[K, T]
 	Entries  []*Entry[K, T] // Contained keys in node
 	Children []*Node[K, T]  // Children nodes
 }
 
 // Entry represents the key-value pair contained within nodes
-type Entry[K, T comparable] struct {
+type Entry[K comparable, T any] struct {
 	Key   K
 	Value T
 }
 
 // NewWith instantiates a B-tree with the order (maximum number of children) and a custom key comparator.
-func NewWith[K, T comparable](order int, comparator utils.Comparator[K]) *Tree[K, T] {
+func NewWith[K comparable, T any](order int, comparator utils.Comparator[K]) *Tree[K, T] {
 	if order < 3 {
 		panic("Invalid order, should be at least 3")
 	}
@@ -57,12 +58,12 @@ func NewWith[K, T comparable](order int, comparator utils.Comparator[K]) *Tree[K
 }
 
 // NewWithNumberComparator instantiates a B-tree with the order (maximum number of children) and the IntComparator, i.e. keys are of type int.
-func NewWithNumberComparator[T comparable](order int) *Tree[int, T] {
+func NewWithNumberComparator[T any](order int) *Tree[int, T] {
 	return NewWith[int, T](order, utils.NumberComparator[int])
 }
 
 // NewWithStringComparator instantiates a B-tree with the order (maximum number of children) and the StringComparator, i.e. keys are of type string.
-func NewWithStringComparator[T comparable](order int) *Tree[string, T] {
+func NewWithStringComparator[T any](order int) *Tree[string, T] {
 	return NewWith[string, T](order, utils.StringComparator)
 }
 
@@ -415,7 +416,7 @@ func (tree *Tree[K, T]) splitRoot() {
 	tree.Root = newRoot
 }
 
-func setParent[K, T comparable](nodes []*Node[K, T], parent *Node[K, T]) {
+func setParent[K comparable, T any](nodes []*Node[K, T], parent *Node[K, T]) {
 	for _, node := range nodes {
 		node.Parent = parent
 	}

--- a/trees/btree/btree_test.go
+++ b/trees/btree/btree_test.go
@@ -7,9 +7,10 @@ package btree
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ugurcsen/gods-generic/utils"
 	"strings"
 	"testing"
+
+	"github.com/ugurcsen/gods-generic/utils"
 )
 
 func TestBTreeGet1(t *testing.T) {
@@ -1044,13 +1045,13 @@ func TestBTreeSearch(t *testing.T) {
 	}
 }
 
-func assertValidTree[K, T comparable](t *testing.T, tree *Tree[K, T], expectedSize int) {
+func assertValidTree[K comparable, T any](t *testing.T, tree *Tree[K, T], expectedSize int) {
 	if actualValue, expectedValue := tree.size, expectedSize; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v for tree size", actualValue, expectedValue)
 	}
 }
 
-func assertValidTreeNode[K, T comparable](t *testing.T, node *Node[K, T], expectedEntries int, expectedChildren int, keys []K, hasParent bool) {
+func assertValidTreeNode[K comparable, T any](t *testing.T, node *Node[K, T], expectedEntries int, expectedChildren int, keys []K, hasParent bool) {
 	if actualValue, expectedValue := node.Parent != nil, hasParent; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v for hasParent", actualValue, expectedValue)
 	}

--- a/trees/btree/iterator.go
+++ b/trees/btree/iterator.go
@@ -10,7 +10,7 @@ import "github.com/ugurcsen/gods-generic/containers"
 var _ containers.ReverseIteratorWithKey[int, int] = (*Iterator[int, int])(nil)
 
 // Iterator holding the iterator's state
-type Iterator[K, T comparable] struct {
+type Iterator[K comparable, T any] struct {
 	tree     *Tree[K, T]
 	node     *Node[K, T]
 	entry    *Entry[K, T]

--- a/trees/redblacktree/iterator.go
+++ b/trees/redblacktree/iterator.go
@@ -10,7 +10,7 @@ import "github.com/ugurcsen/gods-generic/containers"
 var _ containers.ReverseIteratorWithKey[int, int] = (*Iterator[int, int])(nil)
 
 // Iterator holding the iterator's state
-type Iterator[K, T comparable] struct {
+type Iterator[K comparable, T any] struct {
 	tree     *Tree[K, T]
 	node     *Node[K, T]
 	position position

--- a/trees/redblacktree/redblacktree.go
+++ b/trees/redblacktree/redblacktree.go
@@ -13,6 +13,7 @@ package redblacktree
 
 import (
 	"fmt"
+
 	"github.com/ugurcsen/gods-generic/trees"
 	"github.com/ugurcsen/gods-generic/utils"
 )
@@ -27,14 +28,14 @@ const (
 )
 
 // Tree holds elements of the red-black tree
-type Tree[K, T comparable] struct {
+type Tree[K comparable, T any] struct {
 	Root       *Node[K, T]
 	size       int
 	Comparator utils.Comparator[K]
 }
 
 // Node is a single element within the tree
-type Node[K, T comparable] struct {
+type Node[K comparable, T any] struct {
 	Key    K
 	Value  T
 	color  color
@@ -44,17 +45,17 @@ type Node[K, T comparable] struct {
 }
 
 // NewWith instantiates a red-black tree with the custom comparator.
-func NewWith[K, T comparable](comparator utils.Comparator[K]) *Tree[K, T] {
+func NewWith[K comparable, T any](comparator utils.Comparator[K]) *Tree[K, T] {
 	return &Tree[K, T]{Comparator: comparator}
 }
 
 // NewWithNumberComparator instantiates a red-black tree with the IntComparator, i.e. keys are of type int.
-func NewWithNumberComparator[T comparable]() *Tree[int, T] {
+func NewWithNumberComparator[T any]() *Tree[int, T] {
 	return &Tree[int, T]{Comparator: utils.NumberComparator[int]}
 }
 
 // NewWithStringComparator instantiates a red-black tree with the StringComparator, i.e. keys are of type string.
-func NewWithStringComparator[T comparable]() *Tree[string, T] {
+func NewWithStringComparator[T any]() *Tree[string, T] {
 	return &Tree[string, T]{Comparator: utils.StringComparator}
 }
 
@@ -296,7 +297,7 @@ func (node *Node[K, T]) String() string {
 	return fmt.Sprintf("%v", node.Key)
 }
 
-func output[K, T comparable](node *Node[K, T], prefix string, isTail bool, str *string) {
+func output[K comparable, T any](node *Node[K, T], prefix string, isTail bool, str *string) {
 	if node.Right != nil {
 		newPrefix := prefix
 		if isTail {
@@ -541,7 +542,7 @@ func (tree *Tree[K, T]) deleteCase6(node *Node[K, T]) {
 	}
 }
 
-func nodeColor[K, T comparable](node *Node[K, T]) color {
+func nodeColor[K comparable, T any](node *Node[K, T]) color {
 	if node == nil {
 		return black
 	}


### PR DESCRIPTION
Hello,

For now, the trees only receive comparable generic type as value. The trees should only care the key type, maybe the value will allow any type. So I change the value generic type to any, and the tests pass.

By the way, thank you for generic type work! Maybe you can consider merge the repo to the `https://github.com/emirpasic/gods` repo for more people can join to improve it.